### PR TITLE
Fix login redirect path and align test imports

### DIFF
--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -2,11 +2,11 @@ import { jest } from '@jest/globals';
 
 document.body.innerHTML = '<form id="loginForm"></form>';
 
-jest.unstable_mockModule('../js/firebase.js', () => ({
+jest.unstable_mockModule('../public/js/firebase.js', () => ({
   auth: {}
 }), { virtual: true });
 
-const { getFirebaseErrorMessage } = await import('../js/auth.js');
+const { getFirebaseErrorMessage } = await import('../public/js/auth.js');
 
 describe('getFirebaseErrorMessage', () => {
   test('maps user-not-found', () => {

--- a/__tests__/check-auth.test.js
+++ b/__tests__/check-auth.test.js
@@ -8,14 +8,14 @@ jest.unstable_mockModule('https://www.gstatic.com/firebasejs/10.4.0/firebase-aut
   signOut: signOutMock
 }));
 
-jest.unstable_mockModule('../js/firebase.js', () => ({
+jest.unstable_mockModule('../public/js/firebase.js', () => ({
   auth: {},
   db: {}
 }), { virtual: true });
 
-jest.unstable_mockModule('../js/toast.js', () => ({ showToast }), { virtual: true });
+jest.unstable_mockModule('../public/js/toast.js', () => ({ showToast }), { virtual: true });
 
-const { handleSignOut } = await import('../js/check-auth.js');
+const { handleSignOut } = await import('../public/js/check-auth.js');
 
 test('handleSignOut shows error toast', async () => {
   signOutMock.mockRejectedValueOnce(new Error('fail'));

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,9 @@ export default [
     }
   },
   {
+    ignores: ['public/functions/**']
+  },
+  {
     files: ['__tests__/**/*.js'],
     languageOptions: {
       globals: {

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -21,7 +21,7 @@ form.addEventListener('submit', async (e) => {
   const password = form.password.value;
   try {
     await signInWithEmailAndPassword(auth, email, password);
-    window.location.href = 'dashboard.html';
+    window.location.href = '../dashboard.html';
   } catch (err) {
     showToast(getFirebaseErrorMessage(err.code), 'error');
     console.error(err);


### PR DESCRIPTION
## Summary
- fix login redirect to dashboard after sign-in
- update tests to reference correct script locations
- ignore server functions in ESLint config

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adf1ca24b0832ea61c54a184fe4b92